### PR TITLE
Throw KommandCancelledError (RecoverableError) when we cancel a Kommand

### DIFF
--- a/Kommander.xcodeproj/project.pbxproj
+++ b/Kommander.xcodeproj/project.pbxproj
@@ -331,9 +331,9 @@
 				81DBBAEE1E768EAE00EF01D8 /* Dispatcher.swift */,
 				81DBBAF51E768EAE00EF01D8 /* MainDispatcher.swift */,
 				81DBBAED1E768EAE00EF01D8 /* CurrentDispatcher.swift */,
+				0DE0DE341FA380CD001FAC71 /* KommandCancelledError.swift */,
 				81DBBAF31E768EAE00EF01D8 /* Kommander.h */,
 				819D15561E769B1B00BB1F07 /* Info.plist */,
-				0DE0DE341FA380CD001FAC71 /* KommandCancelledError.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";

--- a/Kommander.xcodeproj/project.pbxproj
+++ b/Kommander.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0DE0DE351FA380CD001FAC71 /* KommandCancelledError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DE0DE341FA380CD001FAC71 /* KommandCancelledError.swift */; };
 		815B58061E6573C800818819 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 815B58051E6573C800818819 /* AppDelegate.swift */; };
 		815B58081E6573C800818819 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 815B58071E6573C800818819 /* ViewController.swift */; };
 		815B580B1E6573C800818819 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 815B58091E6573C800818819 /* Main.storyboard */; };
@@ -154,6 +155,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0DE0DE341FA380CD001FAC71 /* KommandCancelledError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KommandCancelledError.swift; sourceTree = "<group>"; };
 		815B58031E6573C700818819 /* Major.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Major.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		815B58051E6573C800818819 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		815B58071E6573C800818819 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -331,6 +333,7 @@
 				81DBBAED1E768EAE00EF01D8 /* CurrentDispatcher.swift */,
 				81DBBAF31E768EAE00EF01D8 /* Kommander.h */,
 				819D15561E769B1B00BB1F07 /* Info.plist */,
+				0DE0DE341FA380CD001FAC71 /* KommandCancelledError.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -759,6 +762,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0DE0DE351FA380CD001FAC71 /* KommandCancelledError.swift in Sources */,
 				81DBBAF61E768EAE00EF01D8 /* CurrentDispatcher.swift in Sources */,
 				81DBBAFD1E768EAE00EF01D8 /* Kommander.swift in Sources */,
 				81DBBAFE1E768EAE00EF01D8 /* MainDispatcher.swift in Sources */,

--- a/KommanderTests/KommanderTests.swift
+++ b/KommanderTests/KommanderTests.swift
@@ -125,6 +125,33 @@ class KommanderTests: XCTestCase {
         waitForExpectations(timeout: 100, handler: nil)
     }
 
+    func test_nCalls_andCancel_andRetry() {
+
+        let ex = expectation(description: String(describing: type(of: self)))
+
+        var successes = 0
+        let calls = Int(arc4random_uniform(10) + 1)
+
+        for i in 0..<calls {
+            interactor.getCounter(name: "C\(i)", to: 3)
+                .onSuccess({ (name) in
+                    successes+=1
+                    print("success \(successes)")
+                    if successes>=calls {
+                        ex.fulfill()
+                    }
+                })
+                .onError({ (error) in
+                    ex.fulfill()
+                    XCTFail()
+                })
+                .execute()
+                .cancel(false, after: .seconds(2))
+                .retry(after: .seconds(4))
+        }
+
+        waitForExpectations(timeout: 100, handler: nil)
+    }
     func test_nCalls() {
 
         let ex = expectation(description: String(describing: type(of: self)))

--- a/KommanderTests/KommanderTests.swift
+++ b/KommanderTests/KommanderTests.swift
@@ -147,11 +147,45 @@ class KommanderTests: XCTestCase {
                 })
                 .execute()
                 .cancel(false, after: .seconds(2))
-                .retry(after: .seconds(4))
+                .retry(after: .seconds(5))
         }
 
         waitForExpectations(timeout: 100, handler: nil)
     }
+
+    func test_nCalls_andCancel_andRetryFromError() {
+        let ex = expectation(description: String(describing: type(of: self)))
+
+        var successes = 0
+        let calls = Int(arc4random_uniform(10) + 1)
+
+        for i in 0..<calls {
+            interactor.getCounter(name: "C\(i)", to: 3)
+                .onSuccess({ (name) in
+                    successes+=1
+                    print("success \(successes)")
+                    if successes>=calls {
+                        ex.fulfill()
+                    }
+                })
+                .onError({ (error) in
+                    guard let error = error as? KommandCancelledError<String> else {
+                        ex.fulfill()
+                        XCTFail()
+                        return
+                    }
+
+                    XCTAssertEqual(error.recoveryOptions, ["Retry the Kommand"])
+                    let recoverySuccess = error.attemptRecovery(optionIndex: 0)
+                    XCTAssert(recoverySuccess)
+                })
+                .execute()
+                .cancel(true, after: .seconds(2))
+        }
+
+        waitForExpectations(timeout: 100, handler: nil)
+    }
+
     func test_nCalls() {
 
         let ex = expectation(description: String(describing: type(of: self)))

--- a/Source/Kommand.swift
+++ b/Source/Kommand.swift
@@ -134,7 +134,7 @@ open class Kommand<Result> {
         }
         self.deliverer?.execute {
             if throwingError {
-                self.errorBlock?(CocoaError(.userCancelled))
+                self.errorBlock?(KommandCancelledError(kommand: self))
             }
         }
         if let operation = operation, !operation.isFinished {

--- a/Source/KommandCancelledError.swift
+++ b/Source/KommandCancelledError.swift
@@ -1,0 +1,27 @@
+//
+//  KommandCancelledError.swift
+//  Kommander
+//
+//  Created by Juan Trías on 27/10/17.
+//  Copyright © 2017 Intelygenz. All rights reserved.
+//
+
+import Foundation
+
+public struct KommandCancelledError<Result>: RecoverableError {
+
+    private let kommand: Kommand<Result>
+
+    init(kommand: Kommand<Result>) {
+        self.kommand = kommand
+    }
+
+    public var recoveryOptions: [String] {
+        return ["Retry the Kommand"]
+    }
+
+    public func attemptRecovery(optionIndex recoveryOptionIndex: Int) -> Bool {
+        kommand.retry()
+        return true
+    }
+}

--- a/Source/KommandCancelledError.swift
+++ b/Source/KommandCancelledError.swift
@@ -24,4 +24,5 @@ public struct KommandCancelledError<Result>: RecoverableError {
         kommand.retry()
         return true
     }
+
 }

--- a/Source/Kommander.swift
+++ b/Source/Kommander.swift
@@ -127,4 +127,5 @@ open class Kommander {
             kommand.retry()
         }
     }
+
 }

--- a/Source/Kommander.swift
+++ b/Source/Kommander.swift
@@ -114,4 +114,17 @@ open class Kommander {
         }
     }
 
+    /// Retry [Kommand<Result>] instances collection after delay
+    open func retry<Result>(_ kommands: [Kommand<Result>], after delay: DispatchTimeInterval) {
+        executor.execute(after: delay) {
+            self.retry(kommands)
+        }
+    }
+
+    /// Retry [Kommand<Result>] instances collection
+    open func retry<Result>(_ kommands: [Kommand<Result>]) {
+        for kommand in kommands {
+            kommand.retry()
+        }
+    }
 }


### PR DESCRIPTION
### Issue Link :https://github.com/intelygenz/Kommander-iOS/issues/6:

### Goals :soccer:
Let the user Retry an operation previously cancelled

### Implementation Details :construction:
- Add new method to `retry()` a Kommand
- Return `KommandCancelledError` instead of `CocoaError` when a Kommand is cancelled

### Testing Details :mag:
- `test_nCalls_andCancel_andRetry`
- `test_nCalls_andCancel_andRetryFromError`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intelygenz/kommander-ios/11)
<!-- Reviewable:end -->
